### PR TITLE
Agnostic regex

### DIFF
--- a/src/sensorsio/sentinel2.py
+++ b/src/sensorsio/sentinel2.py
@@ -443,7 +443,7 @@ class Sentinel2:
         r1_masks = sorted(
             storage.agnostic_regex(
                 self.product_dir,
-                "/MASKS/*DTF_R1-D*.tif",
+                "*MASKS/*DTF_R1-D*.tif",
                 s3_context=self.s3_context,
                 use_gdal_adressing=True,
             )
@@ -451,7 +451,7 @@ class Sentinel2:
         r2_masks = sorted(
             storage.agnostic_regex(
                 self.product_dir,
-                "/MASKS/*DTF_R2-D*.tif",
+                "*MASKS/*DTF_R2-D*.tif",
                 s3_context=self.s3_context,
                 use_gdal_adressing=True,
             )

--- a/tests/test_sentinel2.py
+++ b/tests/test_sentinel2.py
@@ -394,4 +394,5 @@ def test_read_incidence_angles_with_zip_file():
     angles_zip = s2_dataset_zip.read_incidence_angles_as_numpy()
 
     for angle, angle_zip in zip(angles, angles_zip):
-        assert np.allclose(angle, angle_zip)
+        assert np.allclose(angle, angle_zip, equal_nan=True)
+

--- a/tests/test_sentinel2.py
+++ b/tests/test_sentinel2.py
@@ -375,3 +375,23 @@ def test_read_incidence_angle_with_bounding_box_as_numpy():
             even_az_box,
             odd_az_box,
         )
+
+
+@pytest.mark.requires_test_data
+def test_read_incidence_angles_with_zip_file():
+    """
+    Test that angles for unzip/zip files are the same
+    """
+    s2_dataset_path = get_sentinel2_l2a_theia_folder()
+    s2_dataset = sentinel2.Sentinel2(s2_dataset_path)
+    s2_dataset_path_zip = s2_dataset_path + ".zip"
+    s2_dataset_zip = sentinel2.Sentinel2(s2_dataset_path_zip)
+
+    # Read angle for regular file
+    angles = s2_dataset.read_incidence_angles_as_numpy()
+
+    # Read angle for zip file
+    angles_zip = s2_dataset_zip.read_incidence_angles_as_numpy()
+
+    for angle, angle_zip in zip(angles, angles_zip):
+        np.allclose(angle, angle_zip)

--- a/tests/test_sentinel2.py
+++ b/tests/test_sentinel2.py
@@ -394,4 +394,4 @@ def test_read_incidence_angles_with_zip_file():
     angles_zip = s2_dataset_zip.read_incidence_angles_as_numpy()
 
     for angle, angle_zip in zip(angles, angles_zip):
-        np.allclose(angle, angle_zip)
+        assert np.allclose(angle, angle_zip)


### PR DESCRIPTION
Very small changes in `build_detectors_masks_path` for the `agnostic_regex` pattern to correct bug discuss in #8 

Also add a test to check that incidence angles read from unzip & zip file are the same. To run the test,  the zip file of the sentinel 2 product should be included in the `SENSORSIO_TEST_DATA_PATH`.